### PR TITLE
Connection dialog problem solved. Now, dialog disappears 

### DIFF
--- a/OBDII-Dashboard/src/main/java/com/sergiojosemp/obddashboard/activity/DiscoverActivity.kt
+++ b/OBDII-Dashboard/src/main/java/com/sergiojosemp/obddashboard/activity/DiscoverActivity.kt
@@ -74,13 +74,15 @@ class DiscoverActivity: AppCompatActivity() {
 
         discoverViewModel.device.observe(this, androidx.lifecycle.Observer {
             obd.num = 2 //TODO remove this - for debugging purpose
-            GlobalScope.launch{ obd.connectToDevice(bluetoothAdapter!!,it.mac!!,discoverViewModel.connecting) } // Separated thread to not to block UI
+            if(it != null) GlobalScope.launch{ obd.connectToDevice(bluetoothAdapter!!,it.mac!!,discoverViewModel.connecting, discoverViewModel.device) } // Separated thread to not to block UI
         })
 
         discoverViewModel.connecting.observe(this, androidx.lifecycle.Observer {
             if(it == false && discoverViewModel.device.value != null) { //Only true if device connected
                 val menuActivity = Intent(this, MenuActivityKT::class.java)
                 startActivity(menuActivity)
+            } else if(it == false && discoverViewModel.device.value == null){
+
             }
         })
 

--- a/OBDII-Dashboard/src/main/java/com/sergiojosemp/obddashboard/activity/MenuActivityKT.kt
+++ b/OBDII-Dashboard/src/main/java/com/sergiojosemp/obddashboard/activity/MenuActivityKT.kt
@@ -179,9 +179,6 @@ class MenuActivityKT : AppCompatActivity(){
         super.onResume()
         val serviceIntent = Intent(this, OBDKotlinCoroutinesTesting::class.java);
         bindService(serviceIntent, serviceConn, Context.BIND_AUTO_CREATE);
-/*
-
-*/
     }
 
     override fun onBackPressed() {

--- a/OBDII-Dashboard/src/main/java/com/sergiojosemp/obddashboard/service/OBDKotlinCoroutinesTesting.kt
+++ b/OBDII-Dashboard/src/main/java/com/sergiojosemp/obddashboard/service/OBDKotlinCoroutinesTesting.kt
@@ -16,6 +16,7 @@ import com.github.pires.obd.enums.AvailableCommandNames
 import com.github.pires.obd.reader.ObdCommandJob
 import com.sergiojosemp.obddashboard.R
 import com.sergiojosemp.obddashboard.activity.StartMenuActivity
+import com.sergiojosemp.obddashboard.model.BluetoothDeviceModel
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -94,7 +95,7 @@ class OBDKotlinCoroutinesTesting(): Service() {
 */
     }
 
-    fun connectToDevice(bluetoothAdapter: BluetoothAdapter, mac: String, progressBar: MutableLiveData<Boolean>?){
+    fun connectToDevice(bluetoothAdapter: BluetoothAdapter, mac: String, progressBar: MutableLiveData<Boolean>?, device :MutableLiveData<BluetoothDeviceModel>?){
         val btDevice = bluetoothAdapter!!.getRemoteDevice(mac)
         try {
             btConnection = btDevice.javaClass.getMethod(
@@ -113,7 +114,8 @@ class OBDKotlinCoroutinesTesting(): Service() {
                 sendAndReceivePrototype() //TODO remove this when dashboard or verbose mode works
             }
         } catch (e: Exception){
-            //progressBar.postValue(false)
+            device?.postValue(null)
+            progressBar?.postValue(false)
             //e.printStackTrace()
             btConnection?.close()
             btConnection = null
@@ -134,9 +136,6 @@ class OBDKotlinCoroutinesTesting(): Service() {
 
 
     fun sendAndReceivePrototype(){
-
-
-
         val BUFFER_SIZE = 1024
         val buffer = ByteArray(5)
         var bytes = 0
@@ -174,7 +173,7 @@ class OBDKotlinCoroutinesTesting(): Service() {
                     btConnection?.close()
                     btConnection = null
                     delay(233L)
-                    connectToDevice(btAdapter!!, mac!!, null)
+                    connectToDevice(btAdapter!!, mac!!, null, null)
                     //}
                 }
             }


### PR DESCRIPTION
when an exception occurs in the connection process. The solution is to pass as argument to the connection function connectToDevice() a new parameter that references to the BluetoothDeviceModel that represents the target device. This way, now we can point to null when the connection procedure fails, thus we can observe this on the UI process, so we can now make to disappear the connecting dialog correctly.